### PR TITLE
Allow story editing

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -40,6 +40,7 @@ class StoriesController < ApplicationController
     if @story.update(story_params)
       redirect_to admin_stories_url, notice: 'The story was successfully updated.'
     else
+      @icons = Icon.where(available: true)
       render :edit , notice: @story.errors
     end
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -6,7 +6,7 @@ class Story < ApplicationRecord
   belongs_to :icon
 
   # Validation
-  validates :title, :brief, :content, presence: true
+  validates :title, :brief, presence: true
 
   translates :title, :brief, :content
   attribute :title


### PR DESCRIPTION
For Redmine #20312. 

- Seems like some front page stories don't have content and look okay. Saving them unedited fails validation, so I'm un-requiring that field.
- Setting `@icons` to re-render the form on fail.