### PR TITLE
Takedown form GDPR text

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,6 +16,7 @@
  *= require nprogress-bootstrap
  *= require headline
  *= require post
+ *= require takedown
  *= require owl.carousel
  *= require arabic
  *= require select2

--- a/app/assets/stylesheets/takedown.scss
+++ b/app/assets/stylesheets/takedown.scss
@@ -1,0 +1,6 @@
+#takedown-submit-text {
+  margin-top: 30px;
+  p {
+    font-size: 15px;
+  }
+}

--- a/app/models/takedown.rb
+++ b/app/models/takedown.rb
@@ -7,7 +7,7 @@ class Takedown < ApplicationRecord
   has_many :images
   accepts_nested_attributes_for :images
 
-  validates_presence_of %i(platform details reason),
+  validates_presence_of %i(platform details reason email),
                         message: 'This field is required'
 
   validates :appealed, inclusion: { in: [true, false], 

--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -43,5 +43,11 @@
     <%= f.input  :details, label: 'Details about the takedown' %>
 
     <%= f.submit 'submit your report', class: 'btn btn-primary' %>
+
+    <div id="takedown-submit-text">
+      <p>By clicking “Submitting Your Report," you consent to share your information with the <%= link_to "https://eff.org", "Electronic Frontier Foundation" %>, which is the operator and data controller for this website. EFF will use your report, according to the <%= link_to "https://www.eff.org/policy", "Privacy Policy" %>, to further the mission of Onlinecensorship.org, including gaining a fuller picture of how companies are enforcing their terms of service to regulate content online, engaging with companies on how they can improve their regulations and reporting mechanisms and processes and raise public awareness about the ways that social media companies regulate speech and how users are affected. We also use your contact information to send you a verification email to confirm your consent.</p>
+
+      <p>EFF will separately ask your permission to share your report with with third parties, such as companies, policymakers and the public, or otherwise publicizing your case.</p>
+    </div>
   <% end %>
 </div>

--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -38,7 +38,7 @@
 
     <%= f.input  :name, label: 'Your name (Optional)' %>
 
-    <%= f.input  :email, label: 'Your email (Optional)' %>
+    <%= f.input  :email, label: 'Your email', required: true %>
 
     <%= f.input  :details, label: 'Details about the takedown' %>
 


### PR DESCRIPTION
Add explanatory text to takedown form, require e-mail

Closes #142