### PR TITLE
Remove translated search

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,6 +4,6 @@ class ApplicationRecord < ActiveRecord::Base
   private
 
   def self.translated_search(attrs)
-    attrs.map { |a| "translations_#{a}" }.join('_or_')
+    attrs.join("_or_")
   end
 end


### PR DESCRIPTION
Fixes #140
The old version didn't work for models that weren't translated. We're not supporting translation anymore, so this treats all search as untranslated.