### PR TITLE
Support both translated and untranslated search

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,11 @@ class ApplicationRecord < ActiveRecord::Base
 
   private
 
-  def self.translated_search(attrs)
+  def self.search_any(attrs)
+    attrs.join("_or_")
+  end
+
+  def self.translated_search_any(attrs)
     attrs.map { |a| "translations_#{a}" }.join("_or_")
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,7 +7,7 @@ class Category < ApplicationRecord
   ## DB relations
   has_many :posts
 
-  ransack_alias :searchable, translated_search(%i(title))
+  ransack_alias :searchable, translated_search_any(%i(title))
 
   # Validation
   validates :title,:color, :presence => true

--- a/app/models/contacts_topic.rb
+++ b/app/models/contacts_topic.rb
@@ -7,7 +7,7 @@ class ContactsTopic < ApplicationRecord
   ## DB relations
   has_many :contacts
 
-  ransack_alias :searchable, translated_search(%i(name))
+  ransack_alias :searchable, translated_search_any(%i(name))
 
   # Validation
   validates :name, :presence => true

--- a/app/models/content_management_page.rb
+++ b/app/models/content_management_page.rb
@@ -6,7 +6,7 @@ class ContentManagementPage < ApplicationRecord
   HARD_CODED_PAGES = %w(how-to-appeal privacy-policy what-we-do
     who-we-are).freeze
 
-  ransack_alias :searchable, translated_search(%i(content page_title))
+  ransack_alias :searchable, translated_search_any(%i(content page_title))
 
   # Validation
   validates :page_title, :content, :presence => true

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -8,7 +8,7 @@ class Country < ApplicationRecord
   has_many :question_users
   has_many :question_answers
 
-  ransack_alias :searchable, translated_search(%i(name))
+  ransack_alias :searchable, translated_search_any(%i(name))
 
   # Validation
   validates :name, :presence => true

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -3,7 +3,7 @@
 # The admin can add questions and answers for the users 
 #
 class Faq < ApplicationRecord
-  ransack_alias :searchable, translated_search(%i(question answer))
+  ransack_alias :searchable, translated_search_any(%i(question answer))
 
   # Validation
   validates :question, :answer, :presence => true

--- a/app/models/further_read.rb
+++ b/app/models/further_read.rb
@@ -3,7 +3,7 @@
 # The admin can add posts in the section further read
 #
 class FurtherRead < ApplicationRecord
-  ransack_alias :searchable, translated_search(%i(title author written_in))
+  ransack_alias :searchable, translated_search_any(%i(title author written_in))
 
   # Validation
   validates :title, :category ,:author ,:link, :presence => true

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -8,7 +8,7 @@ class Language < ApplicationRecord
   ## DB relations
   has_many :question_answers
 
-  ransack_alias :searchable, translated_search(%i(name))
+  ransack_alias :searchable, translated_search_any(%i(name))
 
   # Validation
   validates :name, :presence => true

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -27,5 +27,5 @@ class Person < ApplicationRecord
   attribute :bio
   attribute :role
 
-  ransack_alias :searchable, translated_search(%i(name bio role))
+  ransack_alias :searchable, translated_search_any(%i(name bio role))
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,7 +26,7 @@ class Post < ApplicationRecord
   attribute :pdf_file_size
   attribute :pdf_updated_at
 
-  ransack_alias :searchable, translated_search(%i(title description))
+  ransack_alias :searchable, translated_search_any(%i(title description))
 
   # For gem FriendlyId
   extend FriendlyId

--- a/app/models/posts_theme.rb
+++ b/app/models/posts_theme.rb
@@ -8,7 +8,7 @@ class PostsTheme < ApplicationRecord
   has_and_belongs_to_many :posts
   has_many :quotes
 
-  ransack_alias :searchable, translated_search(%i(title))
+  ransack_alias :searchable, translated_search_any(%i(title))
 
   # Validation
   validates :title, :presence => true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -15,7 +15,7 @@ class Question < ApplicationRecord
                                 reject_if: proc { |attributes| attributes['option_title'].blank? }, # to remove blank field
                                 allow_destroy: true  # to allow admin to remove options
 
-  ransack_alias :searchable, translated_search(%i(question_title))
+  ransack_alias :searchable, translated_search_any(%i(question_title))
 
   # Validation
   validates :question_title,:question_type, :presence => true

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -8,7 +8,7 @@ class Quote < ApplicationRecord
   has_and_belongs_to_many :posts_themes, through: :quotes_posts_themes
   has_and_belongs_to_many :social_media_platforms, through: :quotes_social_media_platforms
 
-  ransack_alias :searchable, translated_search(%i(author quote))
+  ransack_alias :searchable, translated_search_any(%i(author quote))
 
   # change the id order
   default_scope { order("id DESC") }

--- a/app/models/social_media_platform.rb
+++ b/app/models/social_media_platform.rb
@@ -9,7 +9,7 @@ class SocialMediaPlatform < ApplicationRecord
   has_many :posts
   has_many :quotes
 
-  ransack_alias :searchable, translated_search(%i(title))
+  ransack_alias :searchable, translated_search_any(%i(title))
 
   # For gem FriendlyId
   extend FriendlyId

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -13,7 +13,7 @@ class Story < ApplicationRecord
   attribute :brief
   attribute :content
 
-  ransack_alias :searchable, translated_search(%i(title brief content))
+  ransack_alias :searchable, translated_search_any(%i(title brief content))
 
   def photo(*args)
     icon.file(*args)

--- a/app/models/takedown.rb
+++ b/app/models/takedown.rb
@@ -4,7 +4,7 @@ class Takedown < ApplicationRecord
   include CSVing
 
   ransack_alias :searchable,
-                translated_search(%i(platform details reason email name))
+                search_any(%i(platform details reason email name))
 
   has_many :images
   accepts_nested_attributes_for :images

--- a/spec/features/admin/admin_search_spec.rb
+++ b/spec/features/admin/admin_search_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Admin search' do
   before { log_in_admin }
 
-  it 'displays results' do
+  it 'displays results of translated models' do
     target = FactoryBot.create(:story, title: 'target')
     other = FactoryBot.create(:story, title: 'other')
     visit admin_stories_path
@@ -11,5 +11,15 @@ RSpec.feature 'Admin search' do
     click_on 'Search'
     expect(page).to have_content(target.title)
     expect(page).not_to have_content(other.title)
+  end
+
+  it 'displays results of untranslated models' do
+    target = FactoryBot.create(:takedown, name: 'target')
+    other = FactoryBot.create(:takedown, name: 'other')
+    visit takedowns_path
+    fill_in 'q_searchable_cont', with: target.name
+    click_on 'Search'
+    expect(page).to have_content(target.name)
+    expect(page).not_to have_content(other.name)
   end
 end


### PR DESCRIPTION
Adds a new search helper for building a search alias string for models that aren't translated.