### PR TITLE
Prettier e-mail confirmation for takedowns

### DIFF
--- a/app/views/mailer/takedown_confirmation.html.erb
+++ b/app/views/mailer/takedown_confirmation.html.erb
@@ -1,7 +1,17 @@
-Thank you for submitting your report through Onlinecensorship.org.
+<p>
+  Thank you for submitting your report through Onlinecensorship.org.
+</p>
 
-Because reports may contain particularly sensitive information, such as racial or ethnic origin, political opinions, and religious or philosophical beliefs, we are asking you to confirm your consent for the <%= link_to "Electronic Frontier Foundation", "https://eff.org" %> to use this information, according to the <%= link_to "Privacy Policy", "https://www.eff.org/policy" %> to further the mission of OnlineCensorship.org, including gaining a fuller picture of how companies are enforcing their terms of service to regulate content online, engaging with companies on how they can improve their regulations and reporting mechanisms and processes and raise public awareness about the ways that social media companies regulate speech and how users are affected.
+<p>
+  Because reports may contain particularly sensitive information, such as racial or ethnic origin, political opinions, and religious or philosophical beliefs, we are asking you to confirm your consent for the <%= link_to "Electronic Frontier Foundation", "https://eff.org" %> to use this information, according to the <%= link_to "Privacy Policy", "https://www.eff.org/policy" %> to further the mission of OnlineCensorship.org, including gaining a fuller picture of how companies are enforcing their terms of service to regulate content online, engaging with companies on how they can improve their regulations and reporting mechanisms and processes and raise public awareness about the ways that social media companies regulate speech and how users are affected.
+</p>
 
-EFF will separately ask your permission to share your report with with third parties, such as companies, policymakers and the public, or otherwise publicizing your case.
+<p>
+  EFF will separately ask your permission to share your report with with third parties, such as companies, policymakers and the public, or otherwise publicizing your case.
+</p>
 
-To confirm your consent, please click this <%= link_to "confirmation link", confirm_takedowns_url(token: @takedown.token) %> or vist <%= confirm_takedowns_url(token: @takedown.token) %>.
+<p>
+  <strong>
+    To confirm your consent, please click this <%= link_to "confirmation link", confirm_takedowns_url(token: @takedown.token) %> or vist <%= confirm_takedowns_url(token: @takedown.token) %>.
+  </strong>
+</p>

--- a/app/views/takedowns/confirm.html.erb
+++ b/app/views/takedowns/confirm.html.erb
@@ -1,1 +1,10 @@
-Thank you for confirming your e-mail.
+<% meta title: "Confirmed" %>
+
+<section class="page-title-wrapper">
+  <div class="container">
+    <h1>Report Confirmed</h1>
+    <p>
+      Thank you for confirming your report.
+    </p>
+  </div>
+</section>


### PR DESCRIPTION
* Add some markup to the confirmation e-mail so the text doesn't appear on a single line.
* Add some markup to the confirmation success page so it doesn't shrink into oblivion.